### PR TITLE
Preserve config keys

### DIFF
--- a/config/forma.php
+++ b/config/forma.php
@@ -1,5 +1,0 @@
-<?php
-
-return [
-    'preserve_keys' => [],
-];

--- a/config/forma.php
+++ b/config/forma.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'preserve_keys' => [],
+];

--- a/src/ConfigController.php
+++ b/src/ConfigController.php
@@ -47,9 +47,7 @@ class ConfigController extends Controller
 
         $data = $this->postProcess($fields->process()->values()->toArray());
 
-        ConfigWriter::ignoreFunctionCalls()
-            ->preserve(config("forma.preserve_keys.{$slug}", []))
-            ->writeMany($slug, $data);
+        ConfigWriter::ignoreFunctionCalls()->mergeMany($slug, $data);
 
         ConfigSaved::dispatch($data);
     }

--- a/src/ConfigController.php
+++ b/src/ConfigController.php
@@ -47,7 +47,9 @@ class ConfigController extends Controller
 
         $data = $this->postProcess($fields->process()->values()->toArray());
 
-        ConfigWriter::ignoreFunctionCalls()->writeMany($slug, $data);
+        ConfigWriter::ignoreFunctionCalls()
+            ->preserve(config("forma.preserve_keys.{$slug}", []))
+            ->writeMany($slug, $data);
 
         ConfigSaved::dispatch($data);
     }


### PR DESCRIPTION
Use `mergeMany` so that existing data is not overwritten.

References: https://github.com/transformstudios/zakat-v3/issues/579