### PR TITLE
Added the other PHP versions that Laravel 9 supports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "license": "mit",
     "type": "statamic-addon",
     "require": {
-        "php": "^8.0||^8.1||^8.2",
+        "php": "^8.0.2||^8.1||^8.2",
         "laravel/framework": "^9.6 || ^10.0",
         "statamic/cms": "^4.0",
         "stillat/proteus": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "license": "mit",
     "type": "statamic-addon",
     "require": {
-        "php": "^8.2",
+        "php": "^8.0||^8.1||^8.2",
         "laravel/framework": "^9.6 || ^10.0",
         "statamic/cms": "^4.0",
         "stillat/proteus": "^2.0"


### PR DESCRIPTION
Hello!

Just a small PR here to re-allow PHP8.0 & PHP8.1 in the composer.json.
Both versions are allowed according to [the Laravel 9 docs](https://laravel.com/docs/9.x/upgrade#updating-dependencies).

PS: I'm open to removing PHP8.0 but I just thought I'd include it because the docs mention it.