### PR TITLE
Configuration improvements

### DIFF
--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -1,10 +1,10 @@
 @extends('statamic::layout')
 
-@section('title', __('Config'))
+@section('title', $title)
 
 @section('content')
     <publish-form
-        title='Configuration'
+        title='{{ $title }}'
         action={{ $route }}
         :blueprint='@json($blueprint)'
         :meta='@json($meta)'

--- a/src/ConfigController.php
+++ b/src/ConfigController.php
@@ -53,10 +53,7 @@ class ConfigController extends Controller
 
         $data = $this->postProcess($fields->process()->values()->toArray());
 
-        $keys = $this->getKeysFromData($data);
-
-        $write = ConfigWriter::replace($keys)
-            ->writeMany($slug, $data);
+        $write = ConfigWriter::writeMany($slug, $data);
 
         ConfigSaved::dispatch($data, $addon);
     }
@@ -72,17 +69,6 @@ class ConfigController extends Controller
         }
 
         return BlueprintAPI::makeFromFields($yaml);
-    }
-
-    private function getKeysFromData($data)
-    {
-        return collect($data)->map(function ($value, $key) {
-            if (is_array($value) && (int)$key != $key) {
-                return $this->getKeysFromData($value);
-            }
-
-            return $key;
-        })->all();
     }
 
     protected function postProcess(array $values): array

--- a/src/Events/ConfigSaved.php
+++ b/src/Events/ConfigSaved.php
@@ -4,12 +4,13 @@ namespace Edalzell\Forma\Events;
 
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use Statamic\Extend\Addon;
 
 class ConfigSaved
 {
     use Dispatchable, SerializesModels;
 
-    public function __construct(public array $config)
+    public function __construct(public array $config, public Addon $addon)
     {
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Edalzell\Forma;
 
-use Statamic\Facades\Permission;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Statamic;
 
@@ -18,14 +17,7 @@ class ServiceProvider extends AddonServiceProvider
         parent::boot();
 
         Statamic::booted(function () {
-            $this->bootPermissions();
             Forma::all()->each->boot();
         });
-    }
-
-    private function bootPermissions()
-    {
-        Permission::register('manage addon settings')
-            ->label('Manage Addon Settings');
     }
 }


### PR DESCRIPTION
Prepare for a totally unsolicited PR. When working on some changes/improvements to the Mailchimp add-on, it seems most of what I would want to change was in Forma :)

So this PR:
- Allows you to specify tabs & sections instead of just fields (this works by checking if you have 'tabs' in your config YAML)
- Changes the title of the page in the header and makes it translatable
- Passes the add-on to the ConfigSaved event so you know what add-on was saved
- Allows the nav icon & section to be specified
- Makes permissions specific to the add-on not forma generally